### PR TITLE
Fix __all__ for wild import

### DIFF
--- a/src/mxnet_container/__init__.py
+++ b/src/mxnet_container/__init__.py
@@ -14,4 +14,4 @@
 from mxnet_container.train import train
 from mxnet_container.serve.transformer import load_dependencies, transformer
 
-__all__ = [train, transformer, load_dependencies]
+__all__ = ['train', 'transformer', 'load_dependencies']

--- a/src/mxnet_container/__init__.py
+++ b/src/mxnet_container/__init__.py
@@ -13,5 +13,3 @@
 
 from mxnet_container.train import train
 from mxnet_container.serve.transformer import load_dependencies, transformer
-
-__all__ = ['train', 'transformer', 'load_dependencies']


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To enable wild import, the modules specified in __all__ should be module names(string) instead of modules themselves.

Seems no change log here, so no change for that.
Didn't add any unit tests since wild import cannot be performed within scope of a test function. And adding wild import at top of a test file seems an overkill...

Reference: https://docs.python.org/3/tutorial/modules.html#importing-from-a-package

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
