### PR TITLE
Allow the user script to be mounted locally.

### DIFF
--- a/src/mxnet_container/train.py
+++ b/src/mxnet_container/train.py
@@ -165,7 +165,9 @@ def train(base_dir=MXNetTrainingEnvironment.BASE_DIRECTORY):
     mxnet_env = MXNetTrainingEnvironment(base_dir)
     logger.info("MXNetTrainingEnvironment: {}".format(repr(mxnet_env.__dict__)))
 
-    mxnet_env.download_user_module()
+    if mxnet_env.user_script_archive.lower().startswith('s3://'):
+        mxnet_env.download_user_module()
+
     logger.info("Starting distributed training task")
     if mxnet_env.current_host_scheduler:
         _run_mxnet_process("scheduler", mxnet_env)


### PR DESCRIPTION
If the user script URI is an S3 URI we will download it, otherwise
we assume that the file is already present in the container. (Local
mode will mount it).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
